### PR TITLE
feat: add ls alias for list command (refs A-core#52)

### DIFF
--- a/src/A_vorto/cli.py
+++ b/src/A_vorto/cli.py
@@ -42,7 +42,8 @@ app = typer.Typer(
 )
 
 
-@app.command()
+@app.command("ls")
+@app.command("list", hidden=True)
 def list(
     order_by: str = typer.Option(
         "teksto",


### PR DESCRIPTION
Adds `ls` as primary command name for listing entries, with `list` kept as hidden deprecated alias. Part of the CLI Command Standard rollout from A-core#52.