### PR TITLE
feat: duplicate detection and confirmation prompt for aldoni (closes #21)

### DIFF
--- a/src/A_vorto/cli.py
+++ b/src/A_vorto/cli.py
@@ -9,9 +9,9 @@ from A import error, info, tr_multi
 from A.utils.output import console, print_table
 
 from A_vorto.service import get_service
-from A_vorto.display_helpers import _show_entry
+from A_vorto.display_helpers import _show_entry, _preview_entry
 from A_vorto.search_helpers import _run_search, _display_search_results
-from A_vorto.modify_helpers import _build_create_data, _build_update_data, _handle_create_result
+from A_vorto.modify_helpers import _build_create_data, _build_update_data, _handle_create_result, _find_duplicate
 from A_vorto.manage_helpers import _handle_forigi, _handle_malfari, _handle_rubujo, _handle_restaurigi, _handle_senrubujigi
 from A_vorto.import_export_helpers import _handle_import, _handle_export
 
@@ -196,10 +196,17 @@ def aldoni(
         "--semantika-kopii",
         help=tr_multi("Copy [teksto](#uuid) to clipboard", "Copy [teksto](#uuid) to clipboard", "Copier [texte](#uuid) dans le presse-papiers"),
     ),
+    yes: bool = typer.Option(
+        False,
+        "-y",
+        "--yes",
+        help=tr_multi("Skip confirmation prompt", "Skip confirmation prompt", "Preterpasi konfirmon"),
+    ),
 ) -> None:
-    """Add a new word entry."""
+    """Add a new word entry. Checks for duplicates and confirms before creating."""
     service = get_service()
 
+    # Build creation data
     data = _build_create_data(
         teksto=teksto,
         lingvo=lingvo,
@@ -216,6 +223,41 @@ def aldoni(
         verko=verko,
     )
 
+    # Check for duplicate by teksto
+    existing = _find_duplicate(teksto)
+    if existing:
+        info(tr_multi(
+            f"Jam ekzistas: \"{existing['teksto']}\" (#{existing['uuid'][:8]})",
+            f"Already exists: \"{existing['teksto']}\" (#{existing['uuid'][:8]})",
+            f"Existe deja: \"{existing['teksto']}\" (#{existing['uuid'][:8]})",
+        ))
+        if not yes:
+            replace = typer.confirm(tr_multi(
+                "Anstatauigi la ekzistantan?",
+                "Replace the existing entry?",
+                "Remplacer l'entree existante?",
+            ), default=False)
+            if not replace:
+                info(tr_multi("Nuligita", "Cancelled", "Annule"))
+                return
+        # Update existing entry
+        entry = service.update(existing["uuid"], data)
+        info(tr_multi(f"Gxisdatigis {teksto}", f"Updated {teksto}", f"Mis a jour {teksto}"))
+        return
+
+    # Preview before creation
+    if not yes:
+        _preview_entry(data)
+        confirmed = typer.confirm(tr_multi(
+            "Cxu krei tiun eniron?",
+            "Create this entry?",
+            "Creer cette entree?",
+        ), default=True)
+        if not confirmed:
+            info(tr_multi("Nuligita", "Cancelled", "Annule"))
+            return
+
+    # Create entry
     entry = service.create(data)
     _handle_create_result(entry, teksto, kopii, semantika_kopii)
 

--- a/src/A_vorto/display_helpers.py
+++ b/src/A_vorto/display_helpers.py
@@ -254,4 +254,40 @@ def _show_references(service: Any, entry: dict[str, Any]) -> None:
             console.print(f"  {exists_mark} {display}")
 
 
-__all__ = ["show_field", "_show_entry"]
+def _preview_entry(data: dict[str, Any]) -> None:
+    """Show a compact text preview of entry data before creation.
+
+    Args:
+        data: Entry data dict (teksto, lingvo, tipo, difinoj, etc.)
+    """
+    lines: list[str] = []
+    lines.append(f"[bold]{data.get('teksto', '')}[/]")
+
+    parts: list[str] = []
+    if data.get("lingvo"):
+        parts.append(str(data["lingvo"]))
+    tipo = data.get("tipo", "")
+    if tipo:
+        parts.append(str(tipo) if isinstance(tipo, str) else ", ".join(tipo))
+    if parts:
+        lines.append(f"[dim]{' | '.join(parts)}[/]")
+
+    difinoj = data.get("difinoj", [])
+    if difinoj:
+        if isinstance(difinoj, str):
+            try:
+                difinoj = json.loads(difinoj)
+            except (json.JSONDecodeError, TypeError):
+                difinoj = []
+        if difinoj:
+            lines.append("")
+            for d in difinoj[:3]:
+                lines.append(f"  {d}")
+            if len(difinoj) > 3:
+                lines.append(f"  ... ({len(difinoj)} difinoj)")
+
+    for line in lines:
+        console.print(line)
+
+
+__all__ = ["show_field", "_show_entry", "_preview_entry"]

--- a/src/A_vorto/modify_helpers.py
+++ b/src/A_vorto/modify_helpers.py
@@ -11,6 +11,28 @@ from A.utils.output import console
 from A_vorto.service import get_service
 
 
+def _find_duplicate(teksto: str) -> dict[str, Any] | None:
+    """Check if an entry with the same teksto already exists.
+
+    Performs case-insensitive exact match (not prefix).
+    Returns the existing entry dict if found, None otherwise.
+
+    Args:
+        teksto: The word text to check.
+
+    Returns:
+        Existing entry dict or None.
+    """
+    service = get_service()
+    from A_vorto.data.storage import get_db
+    db = get_db()
+    row = db.execute_one(
+        "SELECT * FROM vorto WHERE LOWER(teksto) = ? AND forigita_je IS NULL",
+        (teksto.lower(),),
+    )
+    return dict(row) if row else None
+
+
 def _build_create_data(
     teksto: str,
     lingvo: str | None = None,


### PR DESCRIPTION
## Summary

Implements the two features requested in issue #21:

### 1. Duplicate Verification
- Before creating, checks if `teksto` exists via case-insensitive exact match
- If found: shows "Jam ekzistas: word (#uuid)" and asks "Anstatauigi?"
- If user confirms: updates the existing entry (modify flow) instead of creating duplicate
- If not: cancels

### 2. Preview + Confirmation
- Shows compact text preview of the entry before creation
- Asks "[J/n] Cxu krei tiun eniron?"
- `--yes` / `-y` flag skips confirmation for scripting/batch operations

### Matching autish-legacy behavior
- Same duplicate detection flow
- Same confirmation pattern
- Extra --yes flag (improvement over legacy)

### Files changed
- `cli.py`: added --yes flag, duplicate branching, preview call
- `display_helpers.py`: added `_preview_entry()` compact preview
- `modify_helpers.py`: added `_find_duplicate()` helper