### PR TITLE
fix: resolve inline refs in difinoj/uzoj display (fixes #28)

### DIFF
--- a/src/A_vorto/display_helpers.py
+++ b/src/A_vorto/display_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from rich.panel import Panel
@@ -10,6 +11,15 @@ from rich.text import Text
 
 from A import tr_multi, copy_to_clipboard
 from A.utils.output import console
+from A.core.references import resolve as resolve_ref
+
+# Regex for inline refs: [label](#uuid), [label](ec#uuid), bare #uuid, bare ec#/vt#uuid
+_INLINE_REF_RE = re.compile(
+    r"\[([^\]]*)\]\((?:#|(?:ec|vt)#)([0-9a-f]{4,})\)"
+    r"|#([0-9a-f]{8})"
+    r"|\b(ec|vt)#([0-9a-f]{8})\b",
+    re.IGNORECASE,
+)
 
 
 def show_field(label: str, value: Any, cxio: bool = False) -> bool:
@@ -49,6 +59,83 @@ def _format_value(value: Any, empty_label: str = "") -> str:
     if isinstance(value, list):
         return ", ".join(str(v) for v in value)
     return str(value)
+
+
+# Regex for inline refs: [label](#uuid), bare #uuid, ec#uuid, vt#uuid
+# Groups: 1=label, 2=uuid_from_markdown, 3=bare_hash_uuid, 4=prefix, 5=prefix_uuid
+_INLINE_REF_RE = re.compile(
+    r"\[([^\]]*)\]\((?:#|(?:ec|vt)#)([0-9a-f]{4,})\)"
+    r"|#([0-9a-f]{8})"
+    r"|\b(ec|vt)#([0-9a-f]{8})\b",
+    re.IGNORECASE,
+)
+
+
+def _resolve_inline_refs(text: str, service: Any) -> str:
+    """Resolve inline refs like #uuid, [label](#uuid), ec#uuid to entry text.
+
+    For cross-module refs (ec#uuid, vt#uuid), uses A.core.references.resolve()
+    which can look up entries in both A-vorto and A-encik.
+
+    Args:
+        text: Text that may contain references.
+        service: Vorto service instance for intra-module UUID resolution.
+
+    Returns:
+        Text with resolved references. Unresolvable refs are left unchanged.
+    """
+    if not text:
+        return text
+
+    def _replace(m: re.Match) -> str:
+        label = m.group(1) or ""
+        # Determine UUID and whether it's a cross-module ref
+        if m.group(2):  # [label](#uuid) or [label](ec#uuid) or [label](vt#uuid)
+            uuid = m.group(2)
+            # Check the original text for ec#/vt# prefix
+            full_match = m.group(0)
+            if full_match.startswith("[") and "(ec#" in full_match.lower():
+                return _resolve_cross_module("ec", uuid, label)
+            elif full_match.startswith("[") and "(vt#" in full_match.lower():
+                return _resolve_cross_module("vt", uuid, label)
+            # Bare #uuid inside markdown link
+            target = service.get(uuid)
+            if target:
+                resolved = label or target.get("teksto", "")
+                return f"{resolved} (#{uuid[:8]})"
+            return m.group(0)
+        elif m.group(3):  # bare #uuid
+            uuid = m.group(3)
+            target = service.get(uuid)
+            if target:
+                resolved = label or target.get("teksto", "")
+                return f"{resolved} #{uuid[:8]}"
+            return m.group(0)
+        elif m.group(4):  # ec#uuid or vt#uuid bare ref
+            prefix = m.group(4).lower()
+            uuid = m.group(5)
+            return _resolve_cross_module(prefix, uuid)
+        return m.group(0)
+
+    return _INLINE_REF_RE.sub(_replace, text)
+
+
+def _resolve_cross_module(prefix: str, uuid: str, label: str = "") -> str:
+    """Resolve a cross-module ref (ec#uuid or vt#uuid) using A.core.
+
+    Args:
+        prefix: "ec" or "vt".
+        uuid: UUID to resolve.
+        label: Optional label from markdown link.
+
+    Returns:
+        Resolved CLI string, or original prefix#uuid if unresolvable.
+    """
+    resolved = resolve_ref(prefix, uuid)
+    if resolved and resolved.exists and resolved.title:
+        display = label or resolved.title
+        return f"{display} ({prefix}#{uuid[:8]})"
+    return label or f"{prefix}#{uuid[:8]}"
 
 
 def _show_entry(
@@ -133,15 +220,17 @@ def _show_entry(
 
     if show_field("Difinoj", difinoj):
         section_label = "\n[bold]difinoj:[/]"
+        rendered_difinoj = [_resolve_inline_refs(d, service) for d in difinoj]
+        rendered_uzoj = [_resolve_inline_refs(u, service) for u in uzoj]
         if len(difinoj) == 1:
-            section_label += f"\n[bold]{difinoj[0]}[/]"
-            if uzoj and uzoj[0]:
-                section_label += f"\n[italic]{uzoj[0]}[/]"
+            section_label += f"\n[bold]{rendered_difinoj[0]}[/]"
+            if uzoj and uzoj[0] and rendered_uzoj[0]:
+                section_label += f"\n[italic]{rendered_uzoj[0]}[/]"
         else:
-            for i, d in enumerate(difinoj, 1):
+            for i, d in enumerate(rendered_difinoj, 1):
                 section_label += f"\n[bold]{i}. {d}[/]"
-                if i - 1 < len(uzoj) and uzoj[i - 1]:
-                    section_label += f"\n   [italic]{uzoj[i - 1]}[/]"
+                if i - 1 < len(rendered_uzoj) and rendered_uzoj[i - 1]:
+                    section_label += f"\n   [italic]{rendered_uzoj[i - 1]}[/]"
         lines.append(section_label)
 
     # Tags (show in cxio mode only)
@@ -165,11 +254,24 @@ def _show_entry(
     if show_field("Ligiloj", ligiloj):
         link_texts: list[str] = []
         for link_ref in ligiloj:
-            target = service.get(link_ref)
-            if target:
-                link_texts.append(f"→ {target.get('teksto', '')} ({link_ref[:8]})")
+            raw_ref = str(link_ref or "")
+            # Check for cross-module ref (ec#uuid or vt#uuid)
+            if raw_ref.lower().startswith("ec#") or raw_ref.lower().startswith("vt#"):
+                parts = raw_ref.split("#", 1)
+                if len(parts) == 2:
+                    prefix = parts[0].lower()
+                    link_uuid = parts[1]
+                    resolved = resolve_ref(prefix, link_uuid)
+                    if resolved and resolved.exists and resolved.title:
+                        link_texts.append(f"→ {resolved.title} ({prefix}#{link_uuid[:8]})")
+                    else:
+                        link_texts.append(f"  {prefix}#{link_uuid[:8]} (ne trovita)")
             else:
-                link_texts.append(f"  {link_ref[:8]} (ne trovita)")
+                target = service.get(link_ref)
+                if target:
+                    link_texts.append(f"→ {target.get('teksto', '')} ({raw_ref[:8]})")
+                else:
+                    link_texts.append(f"  {raw_ref[:8]} (ne trovita)")
         if link_texts:
             lines.append("\n".join(link_texts))
 


### PR DESCRIPTION
## Summary

Fixed inline refs like `#uuid`, `ec#uuid`, `vt#uuid` showing raw UUIDs in difinoj/uzoj display. Now resolves to entry text.

### Changes in display_helpers.py:
- `_resolve_inline_refs()`: resolves all ref formats (#uuid, [label](#uuid), ec#uuid, vt#uuid)
- Uses `service.get()` for intra-module, `A.core.references.resolve()` for cross-module
- Updated ligiloj section to handle ec#/vt# prefixed refs

### Verification
```
Before: animé par le seul (#0fa13de7) du gain
After:  animé par le seul (appât #0fa13de7) du gain
```

### Systematic review against autish-legacy
All display features covered: bold/italic formatting, metadata rows, etikedoj, timestamps, cross-module refs, ligiloj resolution.