### PR TITLE
fix: aldoni preview shows all fields + white teksto in vidi

### DIFF
--- a/src/A_vorto/display_helpers.py
+++ b/src/A_vorto/display_helpers.py
@@ -352,37 +352,122 @@ def _show_references(service: Any, entry: dict[str, Any]) -> None:
 
 
 def _preview_entry(data: dict[str, Any]) -> None:
-    """Show a compact text preview of entry data before creation.
+    """Show a full, aligned preview of entry data before creation.
+
+    Displays all fields from the data dict with consistent indentation
+    and formatting. Preceded by 2 blank lines for visual separation.
 
     Args:
         data: Entry data dict (teksto, lingvo, tipo, difinoj, etc.)
     """
-    lines: list[str] = []
-    lines.append(f"[bold]{data.get('teksto', '')}[/]")
+    lines: list[str] = ["", ""]  # 2-blank-line separation
 
-    parts: list[str] = []
-    if data.get("lingvo"):
-        parts.append(str(data["lingvo"]))
-    tipo = data.get("tipo", "")
-    if tipo:
-        parts.append(str(tipo) if isinstance(tipo, str) else ", ".join(tipo))
-    if parts:
-        lines.append(f"[dim]{' | '.join(parts)}[/]")
+    # Helper: format a single-value field
+    def add_field(label: str, value: Any) -> None:
+        if value is not None and value != "" and value != [] and value != {}:
+            if isinstance(value, str):
+                lines.append(f"  [dim]{label}:[/]  {value}")
+            elif isinstance(value, (int, float)):
+                lines.append(f"  [dim]{label}:[/]  {value}")
 
-    difinoj = data.get("difinoj", [])
-    if difinoj:
-        if isinstance(difinoj, str):
+    # Helper: format a list field
+    def add_list_field(label: str, values: list) -> None:
+        if not values:
+            return
+        lines.append(f"")
+        lines.append(f"  [bold]{label}:[/]")
+        for i, v in enumerate(values, 1):
+            if isinstance(v, str):
+                # Truncate long lines for preview
+                display = v[:120] + "..." if len(v) > 120 else v
+                lines.append(f"    {i}. {display}")
+
+    # Helper: format a tags dict
+    def add_tags_field(label: str, tags: Any) -> None:
+        if not tags:
+            return
+        if isinstance(tags, str):
             try:
-                difinoj = json.loads(difinoj)
+                tags = json.loads(tags)
             except (json.JSONDecodeError, TypeError):
-                difinoj = []
-        if difinoj:
-            lines.append("")
-            for d in difinoj[:3]:
-                lines.append(f"  {d}")
-            if len(difinoj) > 3:
-                lines.append(f"  ... ({len(difinoj)} difinoj)")
+                return
+        if not tags:
+            return
+        lines.append(f"")
+        lines.append(f"  [bold]{label}:[/]")
+        if isinstance(tags, dict):
+            for k, v in tags.items():
+                lines.append(f"    [dim]{k}:[/] {v}")
 
+    # --- Primary fields ---
+    teksto = data.get("teksto", "")
+    lines.append(f"  [bold]{teksto}[/]")
+
+    # Info row: lingvo, kategorio, tipo
+    info_parts: list[str] = []
+    if data.get("lingvo"):
+        info_parts.append(str(data["lingvo"]))
+    if data.get("kategorio"):
+        info_parts.append(str(data["kategorio"]))
+    tipo = data.get("tipo")
+    if tipo:
+        tipo_str = str(tipo) if isinstance(tipo, str) else ", ".join(tipo)
+        info_parts.append(tipo_str)
+    if info_parts:
+        lines.append(f"  [dim]{' | '.join(info_parts)}[/]")
+
+    # --- Metadata fields ---
+    add_field("temo", data.get("temo"))
+    add_field("tono", data.get("tono"))
+    add_field("nivelo", data.get("nivelo"))
+    add_field("autoro", data.get("autoro"))
+    add_field("verko", data.get("verko"))
+
+    # --- Difinoj ---
+    difinoj = data.get("difinoj", [])
+    if isinstance(difinoj, str):
+        try:
+            difinoj = json.loads(difinoj)
+        except (json.JSONDecodeError, TypeError):
+            difinoj = []
+    if difinoj:
+        lines.append(f"")
+        lines.append(f"  [bold]difinoj:[/]")
+        for i, d in enumerate(difinoj, 1):
+            display = d[:120] + "..." if len(d) > 120 else d
+            lines.append(f"    {i}. {display}")
+
+    # --- Uzoj ---
+    uzoj = data.get("uzoj", [])
+    if isinstance(uzoj, str):
+        try:
+            uzoj = json.loads(uzoj)
+        except (json.JSONDecodeError, TypeError):
+            uzoj = []
+    if uzoj:
+        lines.append(f"")
+        lines.append(f"  [bold]uzoj:[/]")
+        for i, u in enumerate(uzoj, 1):
+            display = u[:120] + "..." if len(u) > 120 else u
+            lines.append(f"    {i}. {display}")
+
+    # --- Etikedoj (tags) ---
+    add_tags_field("etikedoj", data.get("etikedoj"))
+
+    # --- Ligiloj (links) ---
+    ligiloj = data.get("ligiloj", [])
+    if isinstance(ligiloj, str):
+        try:
+            ligiloj = json.loads(ligiloj)
+        except (json.JSONDecodeError, TypeError):
+            ligiloj = []
+    if ligiloj:
+        lines.append(f"")
+        lines.append(f"  [bold]ligiloj:[/]")
+        for link in ligiloj[:10]:
+            lines.append(f"    → {link[:50]}")
+
+    # Render all lines
     for line in lines:
         console.print(line)
 

--- a/src/A_vorto/display_helpers.py
+++ b/src/A_vorto/display_helpers.py
@@ -167,7 +167,7 @@ def _show_entry(
 
     # Build panel title
     title = Text()
-    title.append(str(entry.get("teksto", "") or ""), style="bold")
+    title.append(str(entry.get("teksto", "") or ""), style="bold white")
     title.append(f"  {entry['uuid'][:8]}", style="dim")
 
     # Build content lines


### PR DESCRIPTION
## Changes

1. **vidi white text**: Entry teksto now renders as `bold white` for better contrast on dark backgrounds (was just `bold`).

2. **aldoni preview rewrite**: `_preview_entry` now shows ALL fields:
   - Primary: teksto (bold)
   - Info row: lingvo | kategorio | tipo (dim, pipe-separated)
   - Metadata: temo, tono, nivelo, autoro, verko (aligned labels)
   - difinoj (numbered, up to 120 chars each)
   - uzoj (numbered)
   - etikedoj (key:value pairs)
   - ligiloj (up to 10)
   - 2 blank lines at start for visual separation

   Old preview only showed: teksto, lingvo, tipo, and up to 3 difinoj.
   Everything else was silently omitted.