### PR TITLE
feat: accept ` : ` as difino-uzo separator in `aldoni -d`

### DIFF
--- a/src/A_vorto/utils.py
+++ b/src/A_vorto/utils.py
@@ -177,6 +177,7 @@ def split_difino_uzo(raw: str) -> tuple[str, str]:
 
     Supported syntaxes:
     - ``difino::uzo`` (preferred — shell-safe, same keystrokes as ``:{...}``)
+    - ``difino : uzo`` (natural language — space-colon-space)
     - ``difino:{uzo}`` (colon-braced — also valid)
     - ``difino:*uzo*`` (legacy)
 
@@ -190,6 +191,10 @@ def split_difino_uzo(raw: str) -> tuple[str, str]:
     # Shell-safe: difino::uzo
     if "::" in text:
         left, right = text.split("::", 1)
+        return left.strip(), right.strip()
+    # Natural language: difino : uzo  (space-colon-space)
+    if " : " in text:
+        left, right = text.split(" : ", 1)
         return left.strip(), right.strip()
     # Preferred: difino:{uzo}
     m_braced = re.match(r"^(.*?):\{(.+)\}$", text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -301,6 +301,38 @@ class TestSplitDifinoUzo:
         assert d == ""
         assert u == ""
 
+    # ── Single colon with surrounding spaces ( : ) ────────────────────────
+
+    def test_single_colon_with_spaces(self):
+        """Space-colon-space splits correctly."""
+        d, u = split_difino_uzo("def : uzo")
+        assert d == "def"
+        assert u == "uzo"
+
+    def test_single_colon_no_leading_space(self):
+        """Colon with space only after does NOT split."""
+        d, u = split_difino_uzo("def: uzo")
+        assert d == "def: uzo"
+        assert u == ""
+
+    def test_single_colon_multiword(self):
+        """Multi-word natural language example with space-colon-space."""
+        d, u = split_difino_uzo("aspect general : une ruine d'allure")
+        assert d == "aspect general"
+        assert u == "une ruine d'allure"
+
+    def test_single_colon_trailing_only(self):
+        """Nothing after colon: normalize strips trailing space, no split."""
+        d, u = split_difino_uzo("def : ")
+        assert d == "def :"
+        assert u == ""
+
+    def test_double_colon_still_takes_priority(self):
+        """Explicit :: takes priority when both :: and  :  are present."""
+        d, u = split_difino_uzo("def : uzo :: extra")
+        assert d == "def : uzo"
+        assert u == "extra"
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # detect_kategorio


### PR DESCRIPTION
Accept ` : ` (space-colon-space) as a natural-language separator between definition and usage example in `-d`/`--difino`.

Closes #37

**Tested:** 94/94 tests pass. All user scenarios verified.