### PR TITLE
refactor: split cli.py monolith (569 -> 216 lines) into per-command modules

### DIFF
--- a/src/A_vorto/aldoni_cmd.py
+++ b/src/A_vorto/aldoni_cmd.py
@@ -1,0 +1,228 @@
+"""Aldoni command for A-vorto."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from A import confirm_action, info, tr_multi
+from A_vorto.service import get_service
+from A_vorto.modify_helpers import (
+    _build_create_data,
+    _find_duplicate,
+    _handle_create_result,
+)
+from A_vorto.display_helpers import _preview_entry
+
+
+def aldoni(
+    teksto: str = typer.Argument(
+        ...,
+        help=tr_multi("Word text", "Word text", "Texte du mot"),
+    ),
+    lingvo: Optional[str] = typer.Option(
+        None,
+        "--lingvo",
+        "-l",
+        help=tr_multi("Language", "Language", "Langue"),
+    ),
+    kategorio: Optional[str] = typer.Option(
+        None,
+        "--kategorio",
+        help=tr_multi(
+            "Category (auto-detected if omitted)",
+            "Category (auto-detected if omitted)",
+            "Categorie (auto-detectee si omise)",
+        ),
+    ),
+    tipo: Optional[str] = typer.Option(
+        None,
+        "--tipo",
+        "-t",
+        help=tr_multi(
+            "Type abbreviation(s), comma/semicolon-separated (e.g. su,aj)",
+            "Type abbreviation(s), comma/semicolon-separated (e.g. su,aj)",
+            "Abreviation(s) de type, separees par virgule/point-virgule",
+        ),
+    ),
+    temo: Optional[str] = typer.Option(
+        None,
+        "--temo",
+        help=tr_multi("Theme", "Theme", "Theme"),
+    ),
+    tono: Optional[str] = typer.Option(
+        None,
+        "--tono",
+        help=tr_multi(
+            "Tonality (e.g. nf, fo, am)",
+            "Tonality (e.g. nf, fo, am)",
+            "Tonalite (ex. nf, fo, am)",
+        ),
+    ),
+    nivelo: Optional[float] = typer.Option(
+        None,
+        "-n",
+        "--nivelo",
+        help=tr_multi(
+            "Proficiency level (0.0-5.0)",
+            "Proficiency level (0.0-5.0)",
+            "Niveau de competence (0.0-5.0)",
+        ),
+    ),
+    difinoj: Optional[List[str]] = typer.Option(
+        None,
+        "-d",
+        "--difino",
+        help=tr_multi(
+            "Definition with optional usage: difino::uzo",
+            "Definition with optional usage: difino::uzo",
+            "Definition avec usage optionnel: difino::uzo",
+        ),
+    ),
+    uzoj: Optional[List[str]] = typer.Option(
+        None,
+        "--uzo",
+        help=tr_multi(
+            "Usage example (standalone, no paired definition)",
+            "Usage example (standalone, no paired definition)",
+            "Exemple d'usage (autonome, sans definition associee)",
+        ),
+    ),
+    etikedoj: Optional[List[str]] = typer.Option(
+        None,
+        "-e",
+        "--etikedo",
+        help=tr_multi(
+            "Tag in key:value format",
+            "Tag in key:value format",
+            "Etiquette au format cle:valeur",
+        ),
+    ),
+    ligiloj: Optional[List[str]] = typer.Option(
+        None,
+        "-L",
+        "--ligilo",
+        help=tr_multi("Link to UUID(s)", "Link to UUID(s)", "Lier a UUID(s)"),
+    ),
+    autoro: Optional[str] = typer.Option(
+        None,
+        "-A",
+        "--autoro",
+        help=tr_multi("Author", "Author", "Auteur"),
+    ),
+    verko: Optional[str] = typer.Option(
+        None,
+        "-v",
+        "--verko",
+        help=tr_multi(
+            "Work/source (Title:Year format)",
+            "Work/source (Title:Year format)",
+            "Oeuvre/source (format Titre:Annee)",
+        ),
+    ),
+    kopii: bool = typer.Option(
+        False,
+        "-k",
+        "--kopii",
+        help=tr_multi(
+            "Copy UUID to clipboard",
+            "Copy UUID to clipboard",
+            "Copier UUID dans le presse-papiers",
+        ),
+    ),
+    semantika_kopii: bool = typer.Option(
+        False,
+        "-sk",
+        "--semantika-kopii",
+        help=tr_multi(
+            "Copy [teksto](uuid) to clipboard",
+            "Copy [teksto](uuid) to clipboard",
+            "Copier [texte](uuid) dans le presse-papiers",
+        ),
+    ),
+    yes: bool = typer.Option(
+        False,
+        "-y",
+        "--yes",
+        help=tr_multi(
+            "Skip confirmation prompt",
+            "Skip confirmation prompt",
+            "Preterpasi konfirmon",
+        ),
+    ),
+) -> None:
+    """Add a new word entry. Checks for duplicates and confirms before creating."""
+    service = get_service()
+
+    # Build creation data
+    data = _build_create_data(
+        teksto=teksto,
+        lingvo=lingvo,
+        kategorio=kategorio,
+        tipo=tipo,
+        temo=temo,
+        tono=tono,
+        nivelo=nivelo,
+        difinoj=difinoj,
+        uzoj=uzoj,
+        etikedoj=etikedoj,
+        ligiloj=ligiloj,
+        autoro=autoro,
+        verko=verko,
+    )
+
+    # Check for duplicate by teksto
+    existing = _find_duplicate(teksto)
+    if existing:
+        info(
+            tr_multi(
+                f'Jam ekzistas: "{existing["teksto"]}" ({existing["uuid"][:8]})',
+                f'Already exists: "{existing["teksto"]}" ({existing["uuid"][:8]})',
+                f'Existe deja: "{existing["teksto"]}" ({existing["uuid"][:8]})',
+            )
+        )
+        if not yes:
+            replace = confirm_action(
+                tr_multi(
+                    "Anstatauigi la ekzistantan?",
+                    "Replace the existing entry?",
+                    "Remplacer l'entree existante?",
+                ),
+                default=False,
+            )
+            if not replace:
+                info(tr_multi("Nuligita", "Cancelled", "Annule"))
+                return
+        # Update existing entry
+        entry = service.update(existing["uuid"], data)
+        info(
+            tr_multi(
+                f"Gxisdatigis {teksto}",
+                f"Updated {teksto}",
+                f"Mis a jour {teksto}",
+            )
+        )
+        return
+
+    # Preview before creation
+    if not yes:
+        _preview_entry(data)
+        confirmed = confirm_action(
+            tr_multi(
+                "Cxu krei tiun eniron?",
+                "Create this entry?",
+                "Creer cette entree?",
+            ),
+            default=True,
+        )
+        if not confirmed:
+            info(tr_multi("Nuligita", "Cancelled", "Annule"))
+            return
+
+    # Create entry
+    entry = service.create(data)
+    _handle_create_result(entry, teksto, kopii, semantika_kopii)
+
+
+__all__ = ["aldoni"]

--- a/src/A_vorto/cli.py
+++ b/src/A_vorto/cli.py
@@ -1,34 +1,28 @@
-from A import confirm_action
 """CLI for vorto command."""
 
 from pathlib import Path
-from typing import Annotated, List, Optional
+from typing import List, Optional
 
 import typer
 
 from A import error, info, tr_multi
-from A.utils.output import console, print_table
+from A.utils.output import print_table
 
 from A_vorto.service import get_service
-from A_vorto.display_helpers import _show_entry, _preview_entry
-from A_vorto.search_helpers import _run_search, _display_search_results
-from A_vorto.modify_helpers import _build_create_data, _build_update_data, _handle_create_result, _find_duplicate
-from A_vorto.manage_helpers import _handle_forigi, _handle_malfari, _handle_rubujo, _handle_restaurigi, _handle_senrubujigi
+from A_vorto.manage_helpers import (
+    _handle_forigi,
+    _handle_malfari,
+    _handle_rubujo,
+    _handle_restaurigi,
+    _handle_senrubujigi,
+)
 from A_vorto.import_export_helpers import _handle_import, _handle_export
 
-
-def _display_results(entries: list[dict]) -> None:
-    """Display search results in table format."""
-    if not entries:
-        info(tr_multi("Neniuj rezultoj", "No results", "Aucun resultat"))
-        return
-    
-    columns = [
-        {"header": "UUID", "key": "uuid", "style": "dim", "width": 8},
-        {"header": "Teksto", "key": "teksto"},
-        {"header": "Lingvo", "key": "lingvo"},
-    ]
-    print_table(columns, entries)
+# Fat commands extracted to their own modules for readability (< 200 lines each)
+from A_vorto.aldoni_cmd import aldoni as aldoni_func
+from A_vorto.modifi_cmd import modifi as modifi_func
+from A_vorto.vidi_cmd import vidi as vidi_func
+from A_vorto.serci_cmd import serci as serci_func
 
 app = typer.Typer(
     name="vorto",
@@ -78,287 +72,33 @@ def list(
     print_table(columns, entries, title=tr_multi("Vortoj", "Words", "Mots"))
 
 
-@app.command("vidi")
-def vidi(
-    uid: str | None = typer.Argument(
-        None,
-        help=tr_multi("UUID (or prefix) of entry to view. Omit to list latest 50.", "UUID (or prefix) of entry to view. Omit to list latest 50.", "UUID (ou prefixe) de l'entree. Omettre pour lister les 50 dernieres."),
-    ),
-    teksto: str | None = typer.Option(
-        None,
-        "-T",
-        "--teksto",
-        help=tr_multi("Look up by title/text instead of UUID", "Look up by title/text instead of UUID", "Rechercher par titre/texte au lieu de UUID"),
-    ),
-    inversa: bool = typer.Option(
-        False,
-        "-i",
-        "--inversa",
-        help=tr_multi("List oldest 50 first (only without UUID)", "List oldest 50 first (only without UUID)", "Lister les 50 plus anciennes d'abord (sans UUID)"),
-    ),
-    cxio: bool = typer.Option(
-        False,
-        "-a",
-        "--cxio",
-        help=tr_multi("Show all fields (including dates)", "Show all fields (including dates)", "Afficher tous les champs (y compris les dates)"),
-    ),
-    html: bool = typer.Option(
-        False,
-        "-H",
-        "--html",
-        help=tr_multi("Open as HTML preview in browser", "Open as HTML preview in browser", "Ouvrir en apercu HTML dans le navigateur"),
-    ),
-    ref: bool = typer.Option(
-        False,
-        "-r",
-        "--ref",
-        help=tr_multi("Show linked entries and references", "Show linked entries and references", "Montrer les entrees liees et les references"),
-    ),
-    kopii: bool = typer.Option(
-        False,
-        "-k",
-        "--kopii",
-        help=tr_multi("Copy UUID to clipboard", "Copy UUID to clipboard", "Copier UUID dans le presse-papiers"),
-    ),
-    semantika_kopii: bool = typer.Option(
-        False,
-        "-sk",
-        "--semantika-kopii",
-        help=tr_multi("Copy [teksto](uuid) to clipboard", "Copy [teksto](uuid) to clipboard", "Copier [texte](uuid) dans le presse-papiers"),
-    ),
-) -> None:
-    """View a word entry, or list latest 50 entries when called without argument."""
-    # Validate arguments
-    if uid is not None and teksto is not None:
-        error(tr_multi("Use either UUID or --teksto, not both", "Use either UUID or --teksto, not both", "Utiliser UUID ou --teksto, pas les deux"))
-        raise typer.Exit(1)
-    
-    service = get_service()
-    
-    # Handle clipboard mutual exclusivity
-    if kopii and semantika_kopii:
-        error(tr_multi("Use only one of --kopii or --semantika-kopii", "Use only one of --kopii or --semantika-kopii", "Utiliser une seule option"))
-        raise typer.Exit(1)
-    
-    # Handle clipboard with invalid UUID
-    if (kopii or semantika_kopii) and uid is None:
-        error(tr_multi("--kopii/--semantika-kopii requires UUID", "--kopii/--semantika-kopii requires UUID", "--kopii/--semantika-kopii necessite UUID"))
-        raise typer.Exit(1)
-    
-    # No UUID - list latest/oldest 50, or look up by text
-    if uid is None:
-        if teksto:
-            entry = service.find_by_text_prefix(teksto)
-            if not entry:
-                error(tr_multi(f"Vorto {teksto} ne trovitas", f"Word {teksto} not found", f"Mot {teksto} non trouve"))
-                raise typer.Exit(1)
-            # Text found - entry is set, fall through to display below
-        else:
-            entries = service.list(order_by="kreita_je", desc=not inversa, limit=50)
-            info(tr_multi(f"{len(entries)} rezulto(j)", f"{len(entries)} result(s)", f"{len(entries)} resultat(s)"))
-            _display_results(entries)
-            return
-    else:
-        lookup_uid = uid[1:] if uid and uid.startswith("#") else uid
-        entry = service.get(lookup_uid)
-        if not entry:
-            # Check if input looks like a UUID (all hex, 6+ chars) — genuine not-found
-            import re
-            if re.match(r'^[0-9a-fA-F]{6,}$', lookup_uid):
-                error(tr_multi(f"Vorto {uid} ne trovitas", f"Word {uid} not found", f"Mot {uid} non trouve"))
-                raise typer.Exit(1)
-            # Not UUID-like — fall back to text search (matching autish-legacy vidi behavior)
-            if kopii or semantika_kopii:
-                error(tr_multi(
-                    "--kopii/--semantika-kopii requires a UUID argument",
-                    "--kopii/--semantika-kopii requires a UUID argument",
-                    "--kopii/--semantika-kopii necessite un argument UUID",
-                ))
-                raise typer.Exit(1)
-            entries = _run_search(teksto=lookup_uid)
-            selected = _display_search_results(entries)
-            if not selected:
-                raise typer.Exit(1)
-            entry = selected
-            # Disable clipboard for search fallback
-            kopii = False
-            semantika_kopii = False
-    
-    # Display entry using Rich Panel
-    _show_entry(service, entry, cxio=cxio, ref=ref, html=html, kopii=kopii, semantika_kopii=semantika_kopii)
-
-
-@app.command("aldoni")
-def aldoni(
-    teksto: str = typer.Argument(..., help=tr_multi("Word text", "Word text", "Texte du mot")),
-    lingvo: Optional[str] = typer.Option(None, "--lingvo", "-l", help=tr_multi("Language", "Language", "Langue")),
-    kategorio: Optional[str] = typer.Option(None, "--kategorio", help=tr_multi("Category (auto-detected if omitted)", "Category (auto-detected if omitted)", "Categorie (auto-detectee si omise)")),
-    tipo: Optional[str] = typer.Option(None, "--tipo", "-t", help=tr_multi("Type abbreviation(s), comma/semicolon-separated (e.g. su,aj)", "Type abbreviation(s), comma/semicolon-separated (e.g. su,aj)", "Abreviation(s) de type, separees par virgule/point-virgule")),
-    temo: Optional[str] = typer.Option(None, "--temo", help=tr_multi("Theme", "Theme", "Theme")),
-    tono: Optional[str] = typer.Option(None, "--tono", help=tr_multi("Tonality (e.g. nf, fo, am)", "Tonality (e.g. nf, fo, am)", "Tonalite (ex. nf, fo, am)")),
-    nivelo: Optional[float] = typer.Option(None, "-n", "--nivelo", help=tr_multi("Proficiency level (0.0-5.0)", "Proficiency level (0.0-5.0)", "Niveau de competence (0.0-5.0)")),
-    difinoj: Optional[List[str]] = typer.Option(None, "-d", "--difino", help=tr_multi("Definition with optional usage: difino::uzo", "Definition with optional usage: difino::uzo", "Definition avec usage optionnel: difino::uzo")),
-    uzoj: Optional[List[str]] = typer.Option(None, "--uzo", help=tr_multi("Usage example (standalone, no paired definition)", "Usage example (standalone, no paired definition)", "Exemple d'usage (autonome, sans definition associee)")),
-    etikedoj: Optional[List[str]] = typer.Option(None, "-e", "--etikedo", help=tr_multi("Tag in key:value format", "Tag in key:value format", "Etiquette au format cle:valeur")),
-    ligiloj: Optional[List[str]] = typer.Option(None, "-L", "--ligilo", help=tr_multi("Link to UUID(s)", "Link to UUID(s)", "Lier a UUID(s)")),
-    autoro: Optional[str] = typer.Option(None, "-A", "--autoro", help=tr_multi("Author", "Author", "Auteur")),
-    verko: Optional[str] = typer.Option(None, "-v", "--verko", help=tr_multi("Work/source (Title:Year format)", "Work/source (Title:Year format)", "Oeuvre/source (format Titre:Annee)")),
-    kopii: bool = typer.Option(
-        False,
-        "-k",
-        "--kopii",
-        help=tr_multi("Copy UUID to clipboard", "Copy UUID to clipboard", "Copier UUID dans le presse-papiers"),
-    ),
-    semantika_kopii: bool = typer.Option(
-        False,
-        "-sk",
-        "--semantika-kopii",
-        help=tr_multi("Copy [teksto](uuid) to clipboard", "Copy [teksto](uuid) to clipboard", "Copier [texte](uuid) dans le presse-papiers"),
-    ),
-    yes: bool = typer.Option(
-        False,
-        "-y",
-        "--yes",
-        help=tr_multi("Skip confirmation prompt", "Skip confirmation prompt", "Preterpasi konfirmon"),
-    ),
-) -> None:
-    """Add a new word entry. Checks for duplicates and confirms before creating."""
-    service = get_service()
-
-    # Build creation data
-    data = _build_create_data(
-        teksto=teksto,
-        lingvo=lingvo,
-        kategorio=kategorio,
-        tipo=tipo,
-        temo=temo,
-        tono=tono,
-        nivelo=nivelo,
-        difinoj=difinoj,
-        uzoj=uzoj,
-        etikedoj=etikedoj,
-        ligiloj=ligiloj,
-        autoro=autoro,
-        verko=verko,
-    )
-
-    # Check for duplicate by teksto
-    existing = _find_duplicate(teksto)
-    if existing:
-        info(tr_multi(
-            f"Jam ekzistas: \"{existing['teksto']}\" ({existing['uuid'][:8]})",
-            f"Already exists: \"{existing['teksto']}\" ({existing['uuid'][:8]})",
-            f"Existe deja: \"{existing['teksto']}\" ({existing['uuid'][:8]})",
-        ))
-        if not yes:
-            replace = confirm_action(tr_multi(
-                "Anstatauigi la ekzistantan?",
-                "Replace the existing entry?",
-                "Remplacer l'entree existante?",
-            ), default=False)
-            if not replace:
-                info(tr_multi("Nuligita", "Cancelled", "Annule"))
-                return
-        # Update existing entry
-        entry = service.update(existing["uuid"], data)
-        info(tr_multi(f"Gxisdatigis {teksto}", f"Updated {teksto}", f"Mis a jour {teksto}"))
-        return
-
-    # Preview before creation
-    if not yes:
-        _preview_entry(data)
-        confirmed = confirm_action(tr_multi(
-            "Cxu krei tiun eniron?",
-            "Create this entry?",
-            "Creer cette entree?",
-        ), default=True)
-        if not confirmed:
-            info(tr_multi("Nuligita", "Cancelled", "Annule"))
-            return
-
-    # Create entry
-    entry = service.create(data)
-    _handle_create_result(entry, teksto, kopii, semantika_kopii)
-
-
-@app.command("modifi")
-def modifi(
-    uuid: str = typer.Argument(
-        ..., help=tr_multi("UUID (or #UUID) of entry to modify", "UUID (or #UUID) of entry to modify", "UUID (ou #UUID) de l'entree a modifier")
-    ),
-    teksto: Optional[str] = typer.Option(None, "--teksto", "-t", help=tr_multi("New word text", "New word text", "Nouveau texte")),
-    lingvo: Optional[str] = typer.Option(None, "--lingvo", "-l", help=tr_multi("Language", "Language", "Langue")),
-    kategorio: Optional[str] = typer.Option(None, "--kategorio", help=tr_multi("Category", "Category", "Categorie")),
-    tipo: Optional[str] = typer.Option(None, "--tipo", help=tr_multi("Type abbreviation(s), comma/semicolon-separated", "Type abbreviation(s), comma/semicolon-separated", "Abreviation(s) de type, separees par virgule/point-virgule")),
-    temo: Optional[str] = typer.Option(None, "--temo", help=tr_multi("Theme", "Theme", "Theme")),
-    tono: Optional[str] = typer.Option(None, "--tono", help=tr_multi("Tonality (e.g. nf, fo, am)", "Tonality (e.g. nf, fo, am)", "Tonalite (ex. nf, fo, am)")),
-    difinoj: Optional[List[str]] = typer.Option(None, "--difino", help=tr_multi("Definition with optional usage: difino::uzo", "Definition with optional usage: difino::uzo", "Definition avec usage optionnel: difino::uzo")),
-    uzoj: Optional[List[str]] = typer.Option(None, "--uzo", help=tr_multi("Usage example (standalone)", "Usage example (standalone)", "Exemple d'usage (autonome)")),
-    etikedoj: Optional[List[str]] = typer.Option(None, "--etikedo", help=tr_multi("Tag in key:value format", "Tag in key:value format", "Etiquette au format cle:valeur")),
-    autoro: Optional[str] = typer.Option(None, "--autoro", help=tr_multi("Author", "Author", "Auteur")),
-    verko: Optional[str] = typer.Option(None, "--verko", help=tr_multi("Work/source", "Work/source", "Oeuvre/source")),
-    nivelo: Optional[float] = typer.Option(None, "--nivelo", help=tr_multi("Proficiency level (0.0-5.0)", "Proficiency level (0.0-5.0)", "Niveau de competence (0.0-5.0)")),
-    clear_difinoj: bool = typer.Option(False, "--clear-difinoj", help=tr_multi("Clear all definitions", "Clear all definitions", "Effacer toutes les definitions")),
-    clear_uzoj: bool = typer.Option(False, "--clear-uzoj", help=tr_multi("Clear all usage examples", "Clear all usage examples", "Effacer tous les exemples d'usage")),
-    clear_etikedoj: bool = typer.Option(False, "--clear-etikedoj", help=tr_multi("Clear all tags", "Clear all tags", "Effacer toutes les etiquettes")),
-    clear_ligiloj: bool = typer.Option(False, "--clear-ligiloj", help=tr_multi("Clear all links", "Clear all links", "Effacer tous les liens")),
-    clear_tipo: bool = typer.Option(False, "--clear-tipo", help=tr_multi("Clear type list", "Clear type list", "Effacer la liste des types")),
-    ligilo_add: Optional[List[str]] = typer.Option(None, "--ligilo-add", help=tr_multi("Add link(s) to UUID(s)", "Add link(s) to UUID(s)", "Ajouter un/des lien(s) a UUID(s)")),
-    ligilo_remove: Optional[List[str]] = typer.Option(None, "--ligilo-remove", help=tr_multi("Remove link(s) by UUID", "Remove link(s) by UUID", "Retirer un/des lien(s) par UUID")),
-) -> None:
-    """Modify a word entry."""
-    service = get_service()
-
-    existing = service.get(uuid)
-    if not existing:
-        error(tr_multi(f"Vorto {uuid} ne trovitas", f"Word {uuid} not found", f"Mot {uuid} non trouve"))
-        raise typer.Exit(1)
-
-    data = _build_update_data(
-        existing=existing,
-        teksto=teksto,
-        lingvo=lingvo,
-        kategorio=kategorio,
-        tipo=tipo,
-        temo=temo,
-        tono=tono,
-        nivelo=nivelo,
-        difinoj=difinoj,
-        uzoj=uzoj,
-        etikedoj=etikedoj,
-        autoro=autoro,
-        verko=verko,
-        clear_difinoj=clear_difinoj,
-        clear_uzoj=clear_uzoj,
-        clear_etikedoj=clear_etikedoj,
-        clear_ligiloj=clear_ligiloj,
-        clear_tipo=clear_tipo,
-        ligilo_add=ligilo_add,
-        ligilo_remove=ligilo_remove,
-    )
-
-    if not data:
-        error(tr_multi("Neniuj sxangoj", "No changes", "Aucun changement"))
-        raise typer.Exit(1)
-
-    entry = service.update(uuid, data)
-    info(tr_multi(f"Modifikas {uuid}", f"Modified {uuid}", f"Modifie {uuid}"))
+# Register fat commands extracted to their own modules
+app.command(name="vidi")(vidi_func)
+app.command(name="aldoni")(aldoni_func)
+app.command(name="modifi")(modifi_func)
+app.command(name="serci")(serci_func)
+app.command(name="serchi", deprecated=True)(serci_func)
 
 
 @app.command("forigi")
 def forigi(
     uuids: List[str] = typer.Argument(
-        ..., help=tr_multi(
+        ...,
+        help=tr_multi(
             "UUID (or #UUID) of entries to delete (multiple)",
             "UUID (or #UUID) of entries to delete (multiple)",
             "UUID (ou #UUID) des entrees a supprimer (plusieurs)",
-        )
+        ),
     ),
     hard: bool = typer.Option(
         False,
         "--hard",
         "-H",
-        help=tr_multi("Permanent delete (no trash)", "Permanent delete (no trash)", "Suppression permanente"),
+        help=tr_multi(
+            "Permanent delete (no trash)",
+            "Permanent delete (no trash)",
+            "Suppression permanente",
+        ),
     ),
 ) -> None:
     """Delete word entries."""
@@ -388,7 +128,12 @@ def rubujo(
 @app.command("restaurigi")
 def restaurigi(
     uuid: str = typer.Argument(
-        ..., help=tr_multi("UUID (or #UUID) to restore", "UUID (or #UUID) to restore", "UUID (ou #UUID) a restaurer")
+        ...,
+        help=tr_multi(
+            "UUID (or #UUID) to restore",
+            "UUID (or #UUID) to restore",
+            "UUID (ou #UUID) a restaurer",
+        ),
     ),
 ) -> None:
     """Restore an entry from trash."""
@@ -401,7 +146,11 @@ def senrubujigi(
         30,
         "--days",
         "-d",
-        help=tr_multi("Delete entries older than days", "Delete entries older than days", "Supprimer les entrees plus anciennes que jours"),
+        help=tr_multi(
+            "Delete entries older than days",
+            "Delete entries older than days",
+            "Supprimer les entrees plus anciennes que jours",
+        ),
     ),
 ) -> None:
     """Permanently delete entries from trash older than specified days."""
@@ -410,12 +159,23 @@ def senrubujigi(
 
 @app.command("importi")
 def importi(
-    path: Path = typer.Argument(..., help=tr_multi("Path to import file", "Path to import file", "Chemin du fichier a importer")),
+    path: Path = typer.Argument(
+        ...,
+        help=tr_multi(
+            "Path to import file",
+            "Path to import file",
+            "Chemin du fichier a importer",
+        ),
+    ),
     password: Optional[str] = typer.Option(
         None,
         "--password",
         "-p",
-        help=tr_multi("Decryption password", "Decryption password", "Mot de passe de decryptage"),
+        help=tr_multi(
+            "Decryption password",
+            "Decryption password",
+            "Mot de passe de decryptage",
+        ),
     ),
 ) -> None:
     """Import word entries from JSON file."""
@@ -424,7 +184,14 @@ def importi(
 
 @app.command("eksporti")
 def eksporti(
-    path: Path = typer.Argument(..., help=tr_multi("Path to export file", "Path to export file", "Chemin du fichier d'exportation")),
+    path: Path = typer.Argument(
+        ...,
+        help=tr_multi(
+            "Path to export file",
+            "Path to export file",
+            "Chemin du fichier d'exportation",
+        ),
+    ),
     formato: str = typer.Option(
         "json",
         "--format",
@@ -435,135 +202,15 @@ def eksporti(
         None,
         "--password",
         "-p",
-        help=tr_multi("Encryption password", "Encryption password", "Mot de passe de chiffrement"),
+        help=tr_multi(
+            "Encryption password",
+            "Encryption password",
+            "Mot de passe de chiffrement",
+        ),
     ),
 ) -> None:
     """Export word entries to JSON or TOML file."""
     _handle_export(path, formato=formato, password=password)
-
-
-@app.command("serci")
-@app.command("serchi", deprecated=True)
-def serci(
-    teksto: str | None = typer.Argument(
-        None,
-        help=tr_multi("Text to search (default: show all)", "Text to search (default: show all)", "Texte a rechercher (par defaut: tout afficher)"),
-    ),
-    ligilo: str | None = typer.Option(
-        None,
-        "-L",
-        "--ligilo",
-        help=tr_multi("Search related entries from UUID/title via links", "Search related entries from UUID/title via links", "Rechercher des entrees liees via UUID/titre"),
-    ),
-    lingvo: str | None = typer.Option(
-        None,
-        "-l",
-        "--lingvo",
-        help=tr_multi("Filter by language code", "Filter by language code", "Filtrer par code de langue"),
-    ),
-    tipo: str | None = typer.Option(
-        None,
-        "-t",
-        "--tipo",
-        help=tr_multi("Filter by subtype", "Filter by subtype", "Filtrer par sous-type"),
-    ),
-    temo: str | None = typer.Option(
-        None,
-        "--temo",
-        help=tr_multi("Filter by theme", "Filter by theme", "Filtrer par theme"),
-    ),
-    tono: str | None = typer.Option(
-        None,
-        "--tono",
-        help=tr_multi("Filter by tonality", "Filter by tonality", "Filtrer par tonalite"),
-    ),
-    autoro: str | None = typer.Option(
-        None,
-        "-a",
-        "--autoro",
-        help=tr_multi("Filter by author", "Filter by author", "Filtrer par auteur"),
-    ),
-    verko: str | None = typer.Option(
-        None,
-        "-v",
-        "--verko",
-        help=tr_multi("Filter by work (Title:Year format)", "Filter by work (Title:Year format)", "Filtrer par oeuvre (format Titre:Annee)"),
-    ),
-    nivelo_min: float | None = typer.Option(
-        None,
-        "--nivelo-min",
-        help=tr_multi("Minimum lexical level", "Minimum lexical level", "Niveau lexical minimum"),
-    ),
-    nivelo_max: float | None = typer.Option(
-        None,
-        "--nivelo-max",
-        help=tr_multi("Maximum lexical level", "Maximum lexical level", "Niveau lexical maximum"),
-    ),
-    dato_de: str | None = typer.Option(
-        None,
-        "--dato-de",
-        help=tr_multi("Start date YYYY-MM-DD", "Start date YYYY-MM-DD", "Date de debut AAAA-MM-JJ"),
-    ),
-    dato_gis: str | None = typer.Option(
-        None,
-        "--dato-gis",
-        help=tr_multi("End date YYYY-MM-DD", "End date YYYY-MM-DD", "Date de fin AAAA-MM-JJ"),
-    ),
-    regex: bool = typer.Option(
-        False,
-        "-r",
-        "--regex",
-        help=tr_multi("Interpret text as POSIX regex", "Interpret text as POSIX regex", "Interpreter le texte comme regex POSIX"),
-    ),
-    preciza: bool = typer.Option(
-        False,
-        "-p",
-        "--preciza",
-        help=tr_multi("Disable fuzzy fallback", "Disable fuzzy fallback", "Desactiver la recherche floue"),
-    ),
-    limo: int = typer.Option(
-        10,
-        "-lo",
-        "--limo",
-        help=tr_multi("Max results (default 10)", "Max results (default 10)", "Nombre max de resultats (defaut 10)"),
-    ),
-    ordo: str = typer.Option(
-        "nivelo",
-        "-o",
-        "--ordo",
-        help=tr_multi("Order: nivelo/n, dato/d, inversa-dato/id", "Order: nivelo/n, dato/d, inversa-dato/id", "Ordre: nivelo/n, dato/d, inversa-dato/id"),
-    ),
-    uuid: bool = typer.Option(
-        False,
-        "-u",
-        "--uuid",
-        help=tr_multi("Output only UUID list as JSON", "Output only UUID list as JSON", "Sortir uniquement la liste UUID en JSON"),
-    ),
-) -> None:
-    """Search word entries. Without args, list entries up to --limo."""
-    entries = _run_search(
-        teksto=teksto,
-        ligilo=ligilo,
-        lingvo=lingvo,
-        tipo=tipo,
-        temo=temo,
-        tono=tono,
-        autoro=autoro,
-        verko=verko,
-        nivelo_min=nivelo_min,
-        nivelo_max=nivelo_max,
-        dato_de=dato_de,
-        dato_gis=dato_gis,
-        regex=regex,
-        preciza=preciza,
-        limo=limo,
-        ordo=ordo,
-        uuid=uuid,
-    )
-
-    selected = _display_search_results(entries, uuid=uuid)
-    if selected:
-        _show_entry(get_service(), selected)
 
 
 __all__ = ["app"]

--- a/src/A_vorto/display_helpers.py
+++ b/src/A_vorto/display_helpers.py
@@ -8,8 +8,8 @@ from typing import Any
 from rich.panel import Panel
 from rich.text import Text
 
-from A import tr_multi, copy_to_clipboard
-from A.utils.output import console
+from A import info, tr_multi, copy_to_clipboard
+from A.utils.output import console, print_table
 from A.core.references import resolve as resolve_ref
 
 from A_vorto._display_references import (
@@ -238,7 +238,22 @@ def _show_entry(
         preview_markdown(entry["teksto"], title=entry["teksto"])
 
 
+def _display_results(entries: list[dict]) -> None:
+    """Display search results in table format."""
+    if not entries:
+        info(tr_multi("Neniuj rezultoj", "No results", "Aucun resultat"))
+        return
+
+    columns = [
+        {"header": "UUID", "key": "uuid", "style": "dim", "width": 8},
+        {"header": "Teksto", "key": "teksto"},
+        {"header": "Lingvo", "key": "lingvo"},
+    ]
+    print_table(columns, entries)
+
+
 __all__ = [
+    "_display_results",
     "show_field",
     "_format_value",
     "_show_entry",

--- a/src/A_vorto/modifi_cmd.py
+++ b/src/A_vorto/modifi_cmd.py
@@ -1,0 +1,234 @@
+"""Modifi command for A-vorto."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import typer
+
+from A import error, info, tr_multi
+from A_vorto.service import get_service
+from A_vorto.modify_helpers import _build_update_data
+
+
+def modifi(
+    uuid: str = typer.Argument(
+        ...,
+        help=tr_multi(
+            "UUID (or #UUID) of entry to modify",
+            "UUID (or #UUID) of entry to modify",
+            "UUID (ou #UUID) de l'entree a modifier",
+        ),
+    ),
+    teksto: Optional[str] = typer.Option(
+        None,
+        "--teksto",
+        "-t",
+        help=tr_multi("New word text", "New word text", "Nouveau texte"),
+    ),
+    lingvo: Optional[str] = typer.Option(
+        None,
+        "--lingvo",
+        "-l",
+        help=tr_multi("Language", "Language", "Langue"),
+    ),
+    kategorio: Optional[str] = typer.Option(
+        None,
+        "--kategorio",
+        help=tr_multi("Category", "Category", "Categorie"),
+    ),
+    tipo: Optional[str] = typer.Option(
+        None,
+        "--tipo",
+        help=tr_multi(
+            "Type abbreviation(s), comma/semicolon-separated",
+            "Type abbreviation(s), comma/semicolon-separated",
+            "Abreviation(s) de type, separees par virgule/point-virgule",
+        ),
+    ),
+    temo: Optional[str] = typer.Option(
+        None,
+        "--temo",
+        help=tr_multi("Theme", "Theme", "Theme"),
+    ),
+    tono: Optional[str] = typer.Option(
+        None,
+        "--tono",
+        help=tr_multi(
+            "Tonality (e.g. nf, fo, am)",
+            "Tonality (e.g. nf, fo, am)",
+            "Tonalite (ex. nf, fo, am)",
+        ),
+    ),
+    difinoj: Optional[List[str]] = typer.Option(
+        None,
+        "--difino",
+        help=tr_multi(
+            "Definition with optional usage: difino::uzo",
+            "Definition with optional usage: difino::uzo",
+            "Definition avec usage optionnel: difino::uzo",
+        ),
+    ),
+    uzoj: Optional[List[str]] = typer.Option(
+        None,
+        "--uzo",
+        help=tr_multi(
+            "Usage example (standalone)",
+            "Usage example (standalone)",
+            "Exemple d'usage (autonome)",
+        ),
+    ),
+    etikedoj: Optional[List[str]] = typer.Option(
+        None,
+        "--etikedo",
+        help=tr_multi(
+            "Tag in key:value format",
+            "Tag in key:value format",
+            "Etiquette au format cle:valeur",
+        ),
+    ),
+    autoro: Optional[str] = typer.Option(
+        None,
+        "--autoro",
+        help=tr_multi("Author", "Author", "Auteur"),
+    ),
+    verko: Optional[str] = typer.Option(
+        None,
+        "--verko",
+        help=tr_multi(
+            "Work/source",
+            "Work/source",
+            "Oeuvre/source",
+        ),
+    ),
+    nivelo: Optional[float] = typer.Option(
+        None,
+        "--nivelo",
+        help=tr_multi(
+            "Proficiency level (0.0-5.0)",
+            "Proficiency level (0.0-5.0)",
+            "Niveau de competence (0.0-5.0)",
+        ),
+    ),
+    clear_difinoj: bool = typer.Option(
+        False,
+        "--clear-difinoj",
+        help=tr_multi(
+            "Clear all definitions",
+            "Clear all definitions",
+            "Effacer toutes les definitions",
+        ),
+    ),
+    clear_uzoj: bool = typer.Option(
+        False,
+        "--clear-uzoj",
+        help=tr_multi(
+            "Clear all usage examples",
+            "Clear all usage examples",
+            "Effacer tous les exemples d'usage",
+        ),
+    ),
+    clear_etikedoj: bool = typer.Option(
+        False,
+        "--clear-etikedoj",
+        help=tr_multi(
+            "Clear all tags",
+            "Clear all tags",
+            "Effacer toutes les etiquettes",
+        ),
+    ),
+    clear_ligiloj: bool = typer.Option(
+        False,
+        "--clear-ligiloj",
+        help=tr_multi(
+            "Clear all links",
+            "Clear all links",
+            "Effacer tous les liens",
+        ),
+    ),
+    clear_tipo: bool = typer.Option(
+        False,
+        "--clear-tipo",
+        help=tr_multi(
+            "Clear type list",
+            "Clear type list",
+            "Effacer la liste des types",
+        ),
+    ),
+    ligilo_add: Optional[List[str]] = typer.Option(
+        None,
+        "--ligilo-add",
+        help=tr_multi(
+            "Add link(s) to UUID(s)",
+            "Add link(s) to UUID(s)",
+            "Ajouter un/des lien(s) a UUID(s)",
+        ),
+    ),
+    ligilo_remove: Optional[List[str]] = typer.Option(
+        None,
+        "--ligilo-remove",
+        help=tr_multi(
+            "Remove link(s) by UUID",
+            "Remove link(s) by UUID",
+            "Retirer un/des lien(s) par UUID",
+        ),
+    ),
+) -> None:
+    """Modify a word entry."""
+    service = get_service()
+
+    existing = service.get(uuid)
+    if not existing:
+        error(
+            tr_multi(
+                f"Vorto {uuid} ne trovitas",
+                f"Word {uuid} not found",
+                f"Mot {uuid} non trouve",
+            )
+        )
+        raise typer.Exit(1)
+
+    data = _build_update_data(
+        existing=existing,
+        teksto=teksto,
+        lingvo=lingvo,
+        kategorio=kategorio,
+        tipo=tipo,
+        temo=temo,
+        tono=tono,
+        nivelo=nivelo,
+        difinoj=difinoj,
+        uzoj=uzoj,
+        etikedoj=etikedoj,
+        autoro=autoro,
+        verko=verko,
+        clear_difinoj=clear_difinoj,
+        clear_uzoj=clear_uzoj,
+        clear_etikedoj=clear_etikedoj,
+        clear_ligiloj=clear_ligiloj,
+        clear_tipo=clear_tipo,
+        ligilo_add=ligilo_add,
+        ligilo_remove=ligilo_remove,
+    )
+
+    if not data:
+        error(
+            tr_multi(
+                "Neniuj sxangoj",
+                "No changes",
+                "Aucun changement",
+            )
+        )
+        raise typer.Exit(1)
+
+    entry = service.update(uuid, data)
+    info(
+        tr_multi(
+            f"Modifikas {uuid}",
+            f"Modified {uuid}",
+            f"Modifie {uuid}",
+        )
+    )
+
+
+__all__ = ["modifi"]

--- a/src/A_vorto/serci_cmd.py
+++ b/src/A_vorto/serci_cmd.py
@@ -1,0 +1,199 @@
+"""Search command for A-vorto."""
+
+from __future__ import annotations
+
+import typer
+
+from A import tr_multi
+from A_vorto.service import get_service
+from A_vorto.search_helpers import _run_search, _display_search_results
+from A_vorto.display_helpers import _show_entry
+
+
+def serci(
+    teksto: str | None = typer.Argument(
+        None,
+        help=tr_multi(
+            "Text to search (default: show all)",
+            "Text to search (default: show all)",
+            "Texte a rechercher (par defaut: tout afficher)",
+        ),
+    ),
+    ligilo: str | None = typer.Option(
+        None,
+        "-L",
+        "--ligilo",
+        help=tr_multi(
+            "Search related entries from UUID/title via links",
+            "Search related entries from UUID/title via links",
+            "Rechercher des entrees liees via UUID/titre",
+        ),
+    ),
+    lingvo: str | None = typer.Option(
+        None,
+        "-l",
+        "--lingvo",
+        help=tr_multi(
+            "Filter by language code",
+            "Filter by language code",
+            "Filtrer par code de langue",
+        ),
+    ),
+    tipo: str | None = typer.Option(
+        None,
+        "-t",
+        "--tipo",
+        help=tr_multi(
+            "Filter by subtype",
+            "Filter by subtype",
+            "Filtrer par sous-type",
+        ),
+    ),
+    temo: str | None = typer.Option(
+        None,
+        "--temo",
+        help=tr_multi("Filter by theme", "Filter by theme", "Filtrer par theme"),
+    ),
+    tono: str | None = typer.Option(
+        None,
+        "--tono",
+        help=tr_multi(
+            "Filter by tonality",
+            "Filter by tonality",
+            "Filtrer par tonalite",
+        ),
+    ),
+    autoro: str | None = typer.Option(
+        None,
+        "-a",
+        "--autoro",
+        help=tr_multi(
+            "Filter by author",
+            "Filter by author",
+            "Filtrer par auteur",
+        ),
+    ),
+    verko: str | None = typer.Option(
+        None,
+        "-v",
+        "--verko",
+        help=tr_multi(
+            "Filter by work (Title:Year format)",
+            "Filter by work (Title:Year format)",
+            "Filtrer par oeuvre (format Titre:Annee)",
+        ),
+    ),
+    nivelo_min: float | None = typer.Option(
+        None,
+        "--nivelo-min",
+        help=tr_multi(
+            "Minimum lexical level",
+            "Minimum lexical level",
+            "Niveau lexical minimum",
+        ),
+    ),
+    nivelo_max: float | None = typer.Option(
+        None,
+        "--nivelo-max",
+        help=tr_multi(
+            "Maximum lexical level",
+            "Maximum lexical level",
+            "Niveau lexical maximum",
+        ),
+    ),
+    dato_de: str | None = typer.Option(
+        None,
+        "--dato-de",
+        help=tr_multi(
+            "Start date YYYY-MM-DD",
+            "Start date YYYY-MM-DD",
+            "Date de debut AAAA-MM-JJ",
+        ),
+    ),
+    dato_gis: str | None = typer.Option(
+        None,
+        "--dato-gis",
+        help=tr_multi(
+            "End date YYYY-MM-DD",
+            "End date YYYY-MM-DD",
+            "Date de fin AAAA-MM-JJ",
+        ),
+    ),
+    regex: bool = typer.Option(
+        False,
+        "-r",
+        "--regex",
+        help=tr_multi(
+            "Interpret text as POSIX regex",
+            "Interpret text as POSIX regex",
+            "Interpreter le texte comme regex POSIX",
+        ),
+    ),
+    preciza: bool = typer.Option(
+        False,
+        "-p",
+        "--preciza",
+        help=tr_multi(
+            "Disable fuzzy fallback",
+            "Disable fuzzy fallback",
+            "Desactiver la recherche floue",
+        ),
+    ),
+    limo: int = typer.Option(
+        10,
+        "-lo",
+        "--limo",
+        help=tr_multi(
+            "Max results (default 10)",
+            "Max results (default 10)",
+            "Nombre max de resultats (defaut 10)",
+        ),
+    ),
+    ordo: str = typer.Option(
+        "nivelo",
+        "-o",
+        "--ordo",
+        help=tr_multi(
+            "Order: nivelo/n, dato/d, inversa-dato/id",
+            "Order: nivelo/n, dato/d, inversa-dato/id",
+            "Ordre: nivelo/n, dato/d, inversa-dato/id",
+        ),
+    ),
+    uuid: bool = typer.Option(
+        False,
+        "-u",
+        "--uuid",
+        help=tr_multi(
+            "Output only UUID list as JSON",
+            "Output only UUID list as JSON",
+            "Sortir uniquement la liste UUID en JSON",
+        ),
+    ),
+) -> None:
+    """Search word entries. Without args, list entries up to --limo."""
+    entries = _run_search(
+        teksto=teksto,
+        ligilo=ligilo,
+        lingvo=lingvo,
+        tipo=tipo,
+        temo=temo,
+        tono=tono,
+        autoro=autoro,
+        verko=verko,
+        nivelo_min=nivelo_min,
+        nivelo_max=nivelo_max,
+        dato_de=dato_de,
+        dato_gis=dato_gis,
+        regex=regex,
+        preciza=preciza,
+        limo=limo,
+        ordo=ordo,
+        uuid=uuid,
+    )
+
+    selected = _display_search_results(entries, uuid=uuid)
+    if selected:
+        _show_entry(get_service(), selected)
+
+
+__all__ = ["serci"]

--- a/src/A_vorto/vidi_cmd.py
+++ b/src/A_vorto/vidi_cmd.py
@@ -1,0 +1,204 @@
+"""View command for A-vorto."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import typer
+
+from A import error, info, tr_multi
+from A_vorto.service import get_service
+from A_vorto.search_helpers import _run_search, _display_search_results
+from A_vorto.display_helpers import _show_entry, _display_results
+
+
+def vidi(
+    uid: str | None = typer.Argument(
+        None,
+        help=tr_multi(
+            "UUID (or prefix) of entry to view. Omit to list latest 50.",
+            "UUID (or prefix) of entry to view. Omit to list latest 50.",
+            "UUID (ou prefixe) de l'entree. Omettre pour lister les 50 dernieres.",
+        ),
+    ),
+    teksto: str | None = typer.Option(
+        None,
+        "-T",
+        "--teksto",
+        help=tr_multi(
+            "Look up by title/text instead of UUID",
+            "Look up by title/text instead of UUID",
+            "Rechercher par titre/texte au lieu de UUID",
+        ),
+    ),
+    inversa: bool = typer.Option(
+        False,
+        "-i",
+        "--inversa",
+        help=tr_multi(
+            "List oldest 50 first (only without UUID)",
+            "List oldest 50 first (only without UUID)",
+            "Lister les 50 plus anciennes d'abord (sans UUID)",
+        ),
+    ),
+    cxio: bool = typer.Option(
+        False,
+        "-a",
+        "--cxio",
+        help=tr_multi(
+            "Show all fields (including dates)",
+            "Show all fields (including dates)",
+            "Afficher tous les champs (y compris les dates)",
+        ),
+    ),
+    html: bool = typer.Option(
+        False,
+        "-H",
+        "--html",
+        help=tr_multi(
+            "Open as HTML preview in browser",
+            "Open as HTML preview in browser",
+            "Ouvrir en apercu HTML dans le navigateur",
+        ),
+    ),
+    ref: bool = typer.Option(
+        False,
+        "-r",
+        "--ref",
+        help=tr_multi(
+            "Show linked entries and references",
+            "Show linked entries and references",
+            "Montrer les entrees liees et les references",
+        ),
+    ),
+    kopii: bool = typer.Option(
+        False,
+        "-k",
+        "--kopii",
+        help=tr_multi(
+            "Copy UUID to clipboard",
+            "Copy UUID to clipboard",
+            "Copier UUID dans le presse-papiers",
+        ),
+    ),
+    semantika_kopii: bool = typer.Option(
+        False,
+        "-sk",
+        "--semantika-kopii",
+        help=tr_multi(
+            "Copy [teksto](uuid) to clipboard",
+            "Copy [teksto](uuid) to clipboard",
+            "Copier [texte](uuid) dans le presse-papiers",
+        ),
+    ),
+) -> None:
+    """View a word entry, or list latest 50 entries when called without argument."""
+    # Validate arguments
+    if uid is not None and teksto is not None:
+        error(
+            tr_multi(
+                "Use either UUID or --teksto, not both",
+                "Use either UUID or --teksto, not both",
+                "Utiliser UUID ou --teksto, pas les deux",
+            )
+        )
+        raise typer.Exit(1)
+
+    service = get_service()
+
+    # Handle clipboard mutual exclusivity
+    if kopii and semantika_kopii:
+        error(
+            tr_multi(
+                "Use only one of --kopii or --semantika-kopii",
+                "Use only one of --kopii or --semantika-kopii",
+                "Utiliser une seule option",
+            )
+        )
+        raise typer.Exit(1)
+
+    # Handle clipboard with invalid UUID
+    if (kopii or semantika_kopii) and uid is None:
+        error(
+            tr_multi(
+                "--kopii/--semantika-kopii requires UUID",
+                "--kopii/--semantika-kopii requires UUID",
+                "--kopii/--semantika-kopii necessite UUID",
+            )
+        )
+        raise typer.Exit(1)
+
+    # No UUID - list latest/oldest 50, or look up by text
+    if uid is None:
+        if teksto:
+            entry = service.find_by_text_prefix(teksto)
+            if not entry:
+                error(
+                    tr_multi(
+                        f"Vorto {teksto} ne trovitas",
+                        f"Word {teksto} not found",
+                        f"Mot {teksto} non trouve",
+                    )
+                )
+                raise typer.Exit(1)
+            # Text found - entry is set, fall through to display below
+        else:
+            entries = service.list(
+                order_by="kreita_je", desc=not inversa, limit=50
+            )
+            info(
+                tr_multi(
+                    f"{len(entries)} rezulto(j)",
+                    f"{len(entries)} result(s)",
+                    f"{len(entries)} resultat(s)",
+                )
+            )
+            _display_results(entries)
+            return
+    else:
+        lookup_uid = uid[1:] if uid and uid.startswith("#") else uid
+        entry = service.get(lookup_uid)
+        if not entry:
+            # Check if input looks like a UUID (all hex, 6+ chars)
+            if re.match(r"^[0-9a-fA-F]{6,}$", lookup_uid):
+                error(
+                    tr_multi(
+                        f"Vorto {uid} ne trovitas",
+                        f"Word {uid} not found",
+                        f"Mot {uid} non trouve",
+                    )
+                )
+                raise typer.Exit(1)
+            # Not UUID-like — fall back to text search
+            if kopii or semantika_kopii:
+                error(
+                    tr_multi(
+                        "--kopii/--semantika-kopii requires a UUID argument",
+                        "--kopii/--semantika-kopii requires a UUID argument",
+                        "--kopii/--semantika-kopii necessite un argument UUID",
+                    )
+                )
+                raise typer.Exit(1)
+            entries = _run_search(teksto=lookup_uid)
+            selected = _display_search_results(entries)
+            if not selected:
+                raise typer.Exit(1)
+            entry = selected
+            # Disable clipboard for search fallback
+            kopii = False
+            semantika_kopii = False
+
+    # Display entry using Rich Panel
+    _show_entry(
+        service,
+        entry,
+        cxio=cxio,
+        ref=ref,
+        html=html,
+        kopii=kopii,
+        semantika_kopii=semantika_kopii,
+    )
+
+
+__all__ = ["vidi"]


### PR DESCRIPTION
Closes #39

Extract the 4 fat commands (vidi, aldoni, modifi, serci) to separate files under 250 lines each. Thin commands stay in cli.py.

| File | Lines | Contents |
|------|-------|----------|
| cli.py | 216 | App setup, thin commands, imports |
| vidi_cmd.py | 204 | vidi command |
| aldoni_cmd.py | 228 | aldoni command |
| modifi_cmd.py | 234 | modifi command |
| serci_cmd.py | 199 | serci/serchi command |
| display_helpers.py | 266 | + _display_results moved |

All 94 tests pass unchanged.