### PR TITLE
refactor: standardize singleton naming and remove intermediate path vars (#21)

### DIFF
--- a/src/A_vorto/data/storage.py
+++ b/src/A_vorto/data/storage.py
@@ -14,9 +14,6 @@ from A.utils.normalize import fold_search_text
 
 from A_vorto.data.migrate import migrate
 
-_DATA_DIR: Path = data_dir()
-_DB_FILE: Path = _DATA_DIR / "vorto.db"
-
 _db_instance: SQLiteDB | None = None
 
 _CREATE_VORTO = """
@@ -56,10 +53,10 @@ CREATE INDEX IF NOT EXISTS idx_vorto_kategorio ON vorto(kategorio);
 
 def ensure_dirs() -> None:
     """Ensure data directory exists."""
-    _DATA_DIR.mkdir(parents=True, exist_ok=True)
+    data_dir().mkdir(parents=True, exist_ok=True)
 
 
-def get_db() -> SQLiteDB:
+def get_db(path: Path | None = None) -> SQLiteDB:
     """Get or create the shared database connection (singleton).
 
     All callers within the same process share one ``SQLiteDB`` instance,
@@ -69,17 +66,22 @@ def get_db() -> SQLiteDB:
     The connection is lazily created on first call and cached in
     ``_db_instance``. Tests can reset the singleton by setting
     ``A_vorto.data.storage._db_instance = None`` in their teardown.
+
+    Args:
+        path: Optional explicit database path. If omitted, defaults to
+            ``data_dir() / "vorto.db"`` (respects ``A_DIR`` env var).
     """
     global _db_instance
     if _db_instance is not None:
         return _db_instance
 
+    db_path = path or data_dir() / "vorto.db"
     ensure_dirs()
-    if not health_check(_DB_FILE):
+    if not health_check(db_path):
         from A.data.base import repair_db as _repair
-        _repair(_DB_FILE)
-    backup_db(_DB_FILE)
-    db = SQLiteDB(_DB_FILE)
+        _repair(db_path)
+    backup_db(db_path)
+    db = SQLiteDB(db_path)
     db.execute(_CREATE_VORTO)
     db.execute(_CREATE_SCHEMA_VERSION)
     for stmt in _CREATE_INDEXES.strip().split(";"):
@@ -103,7 +105,7 @@ def get_backup_targets() -> list[BackupTarget]:
     """Return backup targets for A-vorto."""
     return [
         BackupTarget(
-            path=_DB_FILE,
+            path=data_dir() / "vorto.db",
             category="data",
             module="vorto",
             label="Vorto database",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,11 +22,6 @@ def isolate_vorto(monkeypatch, tmp_path):
     # Redirect ALL A-core paths via A_DIR env var (covers LinksDB too)
     monkeypatch.setenv("A_DIR", str(tmp_path))
 
-    # Reset singletons before patching paths
+    # Reset singletons
     monkeypatch.setattr(storage_module, "_db_instance", None)
     monkeypatch.setattr(service_module, "_vorto_service", None)
-
-    # Redirect A-vorto storage paths (matching ~/.local/share/A/)
-    data_dir_val = tmp_path / "data"
-    monkeypatch.setattr(storage_module, "_DATA_DIR", data_dir_val)
-    monkeypatch.setattr(storage_module, "_DB_FILE", data_dir_val / "vorto.db")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -21,11 +21,11 @@ def temp_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def mock_data_dir(monkeypatch: pytest.MonkeyPatch, temp_dir: Path) -> None:
-    """Mock data directory to temp path."""
+    """Redirect data directory to temp path via A_DIR and reset singleton."""
     import A_vorto.data.storage as storage_module
 
-    monkeypatch.setattr(storage_module, "_DATA_DIR", temp_dir)
-    monkeypatch.setattr(storage_module, "_DB_FILE", temp_dir / "vorto.db")
+    monkeypatch.setenv("A_DIR", str(temp_dir))
+    storage_module._db_instance = None
 
 
 class TestEnsureDirs:
@@ -35,11 +35,11 @@ class TestEnsureDirs:
         """Test that ensure_dirs creates the data directory."""
         import A_vorto.data.storage as storage_module
 
-        # ensure_dirs should create the directory
         storage_module.ensure_dirs()
 
-        assert temp_dir.exists()
-        assert temp_dir.is_dir()
+        expected = temp_dir / "data"
+        assert expected.exists()
+        assert expected.is_dir()
 
 
 class TestGetDb:
@@ -50,14 +50,11 @@ class TestGetDb:
         import A_vorto.data.storage as storage_module
         from A.data.base import SQLiteDB
 
-        # Mock _ensure_dirs to avoid actual filesystem operations
         with patch.object(storage_module, "_ensure_dirs", lambda: None):
             db = storage_module.get_db()
 
-        # Verify it's a SQLiteDB instance
         assert isinstance(db, SQLiteDB)
 
-        # Verify vorto table exists
         result = db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='vorto'")
         assert len(result) == 1
         assert result[0]["name"] == "vorto"
@@ -69,13 +66,11 @@ class TestGetDb:
         with patch.object(storage_module, "_ensure_dirs", lambda: None):
             db = storage_module.get_db()
 
-        # Get all indexes on vorto table
         result = db.execute(
             "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='vorto'"
         )
         index_names = [r["name"] for r in result]
 
-        # Verify expected indexes exist
         assert "idx_vorto_teksto" in index_names
         assert "idx_vorto_lingvo" in index_names
         assert "idx_vorto_kategorio" in index_names
@@ -87,11 +82,9 @@ class TestGetDb:
         with patch.object(storage_module, "_ensure_dirs", lambda: None):
             db = storage_module.get_db()
 
-        # Get column info
         result = db.execute("PRAGMA table_info(vorto)")
         columns = {r["name"]: r for r in result}
 
-        # Verify required columns exist
         required_columns = [
             "uuid", "teksto", "lingvo", "kategorio", "tipo", "temo",
             "tono", "nivelo", "difinoj", "uzoj", "etikedoj", "ligiloj",
@@ -101,11 +94,7 @@ class TestGetDb:
         for col in required_columns:
             assert col in columns, f"Missing column: {col}"
 
-        # Verify teksto is NOT NULL
         assert columns["teksto"]["notnull"] == 1
-
-        # Note: pk info not available in all SQLite versions
-        # UUID is primary key by schema definition
 
 
 class TestGetDbSingleton:
@@ -119,9 +108,6 @@ class TestGetDbSingleton:
             db1 = storage_module.get_db()
             db2 = storage_module.get_db()
 
-        # get_db now caches the instance (singleton pattern)
-        # Same as service singleton — prevents "database is locked" from
-        # multiple connections to the same DB file.
         assert db1 is db2
 
 


### PR DESCRIPTION
### Summary

Implements the 5-phase plan from issue #21:

**Phase 1a** — A-semantika: renamed `_DB` → `_db_instance` in `storage.py` + test files
**Phase 1b** — A-agento: renamed `_db` → `_db_instance` in `_storage_base.py`
**Phase 2** — A-encik, A-vorto, A-organizi, A-medio: removed `_DATA_DIR`/`_DB_FILE` intermediate variables, inlined `data_dir()` calls
**Phase 3** — A-core: added `simulate()` context manager to `A.core.testing` with safety guard

### Testing

- ✅ All existing tests pass (450 A-core, 136 A-encik, 125 A-vorto, 307 A-organizi, 155 A-medio, 155 A-agento, 670 A-semantika)
- ✅ User-simulation smoke tests: 10/11 CLI commands work with `A_DIR` isolation (1 pre-existing: A-organizi has no top-level `ls`)
- ✅ `simulate()` context manager verified: sets `A_DIR`, validates isolation, restores on exit